### PR TITLE
provide optional parameter for client timeout

### DIFF
--- a/inc/websocket.h
+++ b/inc/websocket.h
@@ -45,6 +45,7 @@ struct websocket_init
   void (*ws_onClose)(void *wsDesc, void *clientDesc, void *userData);
   char *address;
   char *port;
+  unsigned long *client_timeout_sec;
 };
 
 /**

--- a/src/socket_server/socket_server.h
+++ b/src/socket_server/socket_server.h
@@ -18,6 +18,7 @@ struct socket_init
   void (*socket_onClose)(void *socketUserData, void *clientDesc, void *clientUserData);
   char *port;
   char *address;
+  unsigned long client_timeout_sec;
 };
 
 void socketServer_closeClient(void *socketClientDesc);

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -1153,6 +1153,12 @@ void *websocket_open(struct websocket_init *wsInit, void *websocketUserData)
 
   socketInit.address = wsInit->address;
   socketInit.port = wsInit->port;
+
+  if(wsInit->client_timeout_sec)
+    socketInit.client_timeout_sec = *(wsInit->client_timeout_sec);
+  else
+    socketInit.client_timeout_sec = 0;
+
   socketInit.socket_onOpen = websocket_onOpen;
   socketInit.socket_onClose = websocket_onClose;
   socketInit.socket_onMessage = websocket_onMessage;


### PR DESCRIPTION
This adds support for an optional timeout in seconds to close a
client-socket after inactivity.

Signed-off-by: Thomas Haemmerle <thomas.haemmerle@wolfvision.net>